### PR TITLE
add mount of licensed tools

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -211,30 +211,28 @@ process {
     withName: INTERPROSCAN {
         cpus   = 16
         memory = { 12.GB * task.attempt }
-        ext.args =
-            "--iprlookup " +
-            "--goterms " +
-            "--applications " + [
+        ext.args = {
+            def applications = [
                 "TIGRFAM",
                 "SFLD",
                 "SUPERFAMILY",
-                "Gene3D",
-                "Hamap",
-                "Coils",
+                "GENE3D",
+                "HAMAP",
+                "COILS",
                 "CDD",
                 "PRINTS",
                 "PIRSF",
-                "ProSiteProfiles",
-                "ProSitePatterns",
-                "PfamA",
-                "MobiDBLite",
-                "SMART",
-                "SignalP_GRAM_POSITIVE",
-                "SignalP_GRAM_NEGATIVE",
-                "SignalP_EUK",
-                "Phobius",
-                "TMHMM",
-        ].join(",")
+                "PROSITEPROFILES",
+                "PROSITEPATTERNS",
+                "PFAM",
+                "MOBIDBLITE",
+                "SMART"
+            ]
+            if ( params.interpro_licensed_software ) {
+                applications << "SIGNALP"
+            }
+            return "--iprlookup --goterms --pathways --applications " + applications.join(",")
+        }
 
         // We override the prefix of the output here because the input is chunked and joined with CAT_CAT
         // and to avoid naming collisions we use the name of the input (which comes from SEQKIT_SPLIT2) that

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -229,11 +229,11 @@ process {
                 "PfamA",
                 "MobiDBLite",
                 "SMART",
-                //"SignalP_GRAM_POSITIVE",
-                //"SignalP_GRAM_NEGATIVE",
-                //"SignalP_EUK",
-                //"Phobius",
-                //"TMHMM",
+                "SignalP_GRAM_POSITIVE",
+                "SignalP_GRAM_NEGATIVE",
+                "SignalP_EUK",
+                "Phobius",
+                "TMHMM",
         ].join(",")
 
         // We override the prefix of the output here because the input is chunked and joined with CAT_CAT

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -28,7 +28,7 @@ params {
     rfam_cm                            = "${projectDir}/tests/reference_databases/rrnas_rfam/ribo.cm"
     rfam_claninfo                      = "${projectDir}/tests/reference_databases/rrnas_rfam/ribo.clan_info"
 
-    interproscan_database              = "${projectDir}/modules/ebi-metagenomics/interproscan/tests/fixtures/interproscan_db/data"
+    interproscan_database              = "${projectDir}/modules/ebi-metagenomics/interproscan/tests/fixtures/interproscan_db"
     interproscan_database_version      = "5.73-104.0"
 
     eggnog_data_dir                    = "${projectDir}/tests/reference_databases/eggnog_mapper/"

--- a/modules/ebi-metagenomics/interproscan/main.nf
+++ b/modules/ebi-metagenomics/interproscan/main.nf
@@ -5,11 +5,29 @@ process INTERPROSCAN {
     container 'microbiome-informatics/interproscan:5.73-104.0'
 
     containerOptions {
+        def dataPath = "${interproscan_db}/data"
+        def licensedPath = "${interproscan_db}/licensed"
+        def containerArgs = []
+
         if (workflow.containerEngine == 'singularity') {
-            return "--bind ${interproscan_db}:/opt/interproscan/data"
+            containerArgs << "--bind ${dataPath}:/opt/interproscan/data"
+
+            if (new File(licensedPath).exists()) {
+                containerArgs << "--bind ${licensedPath}:/opt/interproscan/licensed"
+            }
+
         } else {
-            return "-v ${task.workDir}/${interproscan_db}:/opt/interproscan/data"
+            def workData = "${task.workDir}/${dataPath}"
+            def workLicensed = "${task.workDir}/${licensedPath}"
+
+            containerArgs << "-v ${workData}:/opt/interproscan/data"
+
+            if (new File(workLicensed).exists()) {
+                containerArgs << "-v ${workLicensed}:/opt/interproscan/licensed"
+            }
         }
+
+        return containerArgs.join(' ')
     }
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,7 @@ params {
     // TODO: cat db version from @Sonya
     interproscan_database              = null
     interproscan_database_version      = "5.73-104.0"
-    interpro_licensed_software         = true
+    interpro_licensed_software         = false
 
     eggnog_database                    = null
     eggnog_diamond_database            = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,6 +32,7 @@ params {
     // TODO: cat db version from @Sonya
     interproscan_database              = null
     interproscan_database_version      = "5.73-104.0"
+    interpro_licensed_software         = true
 
     eggnog_database                    = null
     eggnog_diamond_database            = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -129,6 +129,11 @@
                     "description": "The version of the interproscan database.",
                     "fa_icon": "fas fa-code-branch"
                 },
+                "interpro_licensed_software": {
+                    "type": "boolean",
+                    "description": "Enables the use of licensed software in InterProScan. Set to true if the required licensed software is in the licensed database folder, https://interproscan-docs.readthedocs.io/en/v5/HowToRun.html#included-analyses.",
+                    "fa_icon": "fas fa-file-contract"
+                },
                 "eggnog_database": {
                     "type": "string",
                     "format": "file-path",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -131,6 +131,7 @@
                 },
                 "interpro_licensed_software": {
                     "type": "boolean",
+                    "default": false,
                     "description": "Enables the use of licensed software in InterProScan. Set to true if the required licensed software is in the licensed database folder, https://interproscan-docs.readthedocs.io/en/v5/HowToRun.html#included-analyses.",
                     "fa_icon": "fas fa-file-contract"
                 },


### PR DESCRIPTION
We need to add licensed tools to IPS.
**documentation** https://interproscan-docs.readthedocs.io/en/v5/ActivatingLicensedAnalyses.html. I have downloaded all tools locally (I can share those as archive).

I put some on CODON already `/hps/nobackup/rdf/metagenomics/service-team/ref-dbs/ips/5.73-104.0/licensed`
<img width="278" alt="image" src="https://github.com/user-attachments/assets/ce9f1632-b733-4350-98cd-b794b3c27fd1" />

Docker file uses mounts https://github.com/EBI-Metagenomics/containers/blob/master/interproscan/5.73-104.0/Dockerfile#L38

My idea was to have `data` and `licensed` folders and mount them into nextflow module separately. But it doesn't work...