### PR TITLE
Add compression to cat outputs

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -8,64 +8,86 @@
                     "antismash/antismashlite": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/antismash/antismashlite/antismash-antismashlite.diff"
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/cat/cat/cat-cat.diff"
                     },
                     "csvtk/concat": {
                         "branch": "master",
                         "git_sha": "fa92936611247ca647ddee970f94d83f1bcb0ffe",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/csvtk/concat/csvtk-concat.diff"
                     },
                     "hmmer/hmmsearch": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/hmmer/hmmsearch/hmmer-hmmsearch.diff"
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "cf17ca47590cc578dfb47db1c2a44ef86f89976d",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/multiqc/multiqc.diff"
                     },
                     "pigz/uncompress": {
                         "branch": "master",
                         "git_sha": "c70357ea249a541df53dd5b479b3c32b0c26c4d2",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "pyrodigal": {
                         "branch": "master",
                         "git_sha": "938e803109104e30773f76a7142442722498fef1",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "quast": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/quast/quast.diff"
                     },
                     "seqkit/seq": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "seqkit/split2": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/seqkit/split2/seqkit-split2.diff"
                     },
                     "tabix/bgzip": {
                         "branch": "master",
                         "git_sha": "69fdb99a8affa55adfda16966aa4568e103dc1b6",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -74,17 +96,23 @@
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "c2b22d85f30a706a3073387f30380704fcae013b",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "51ae5406a030d4da1e49e4dab49756844fdd6c7a",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "2fd2cd6d0e7b273747f32e465fdc6bcc3ae0814e",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }
@@ -95,129 +123,175 @@
                     "catpack/contigs": {
                         "branch": "main",
                         "git_sha": "b08ed4ae81778706db8c5be504bfd8dd2817a121",
-                        "installed_by": ["contigs_taxonomic_classification"],
+                        "installed_by": [
+                            "contigs_taxonomic_classification"
+                        ],
                         "patch": "modules/ebi-metagenomics/catpack/contigs/catpack-contigs.diff"
                     },
                     "cmsearchtbloutdeoverlap": {
                         "branch": "main",
                         "git_sha": "696324c637a7e0cf06fe331faffee42e36826898",
-                        "installed_by": ["detect_rna"]
+                        "installed_by": [
+                            "detect_rna"
+                        ]
                     },
                     "combinedgenecaller/merge": {
                         "branch": "main",
                         "git_sha": "b84a0c52b92eef58ba2aeb2d22ae45d5bc6ae294",
-                        "installed_by": ["combined_gene_caller"],
+                        "installed_by": [
+                            "combined_gene_caller"
+                        ],
                         "patch": "modules/ebi-metagenomics/combinedgenecaller/merge/combinedgenecaller-merge.diff"
                     },
                     "convertcmscantocmsearch": {
                         "branch": "main",
                         "git_sha": "937985d6147b25b74700f2eb6fc41ab4150ad7d4",
-                        "installed_by": ["detect_rna"],
+                        "installed_by": [
+                            "detect_rna"
+                        ],
                         "patch": "modules/ebi-metagenomics/convertcmscantocmsearch/convertcmscantocmsearch.diff"
                     },
                     "dbcan/dbcan": {
                         "branch": "main",
                         "git_sha": "2f2f837279b44825254ea736b12ea4797b350d0a",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/ebi-metagenomics/dbcan/dbcan/dbcan-dbcan.diff"
                     },
                     "diamond/blastp": {
                         "branch": "main",
                         "git_sha": "f85a33e88680924f76aaccb3c120983ff4134747",
-                        "installed_by": ["contigs_taxonomic_classification"]
+                        "installed_by": [
+                            "contigs_taxonomic_classification"
+                        ]
                     },
                     "dram/distill": {
                         "branch": "main",
                         "git_sha": "2ba3fbfba678c0c8e1e7537fa908b04575b5b916",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "easel/eslsfetch": {
                         "branch": "main",
                         "git_sha": "f1bf089cb679ca1e363aa81c99a512114402472c",
-                        "installed_by": ["detect_rna"]
+                        "installed_by": [
+                            "detect_rna"
+                        ]
                     },
                     "extractcoords": {
                         "branch": "main",
                         "git_sha": "33ea81307e5bf9772861d2a3cb1b4f4694a04db6",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/ebi-metagenomics/extractcoords/extractcoords.diff"
                     },
                     "fraggenescanrs": {
                         "branch": "main",
                         "git_sha": "67fa3c30f1488ebacb1f1a1304cc1c8b43e92e3d",
-                        "installed_by": ["combined_gene_caller"]
+                        "installed_by": [
+                            "combined_gene_caller"
+                        ]
                     },
                     "generategaf": {
                         "branch": "main",
                         "git_sha": "31e6276eef26fec7160c53a575b6e27b7ff842a5",
-                        "installed_by": ["goslim_swf"],
+                        "installed_by": [
+                            "goslim_swf"
+                        ],
                         "patch": "modules/ebi-metagenomics/generategaf/generategaf.diff"
                     },
                     "genomeproperties": {
                         "branch": "main",
                         "git_sha": "7c67b0652fb83c8239bd5bace72364f6676e3e39",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/ebi-metagenomics/genomeproperties/genomeproperties.diff"
                     },
                     "infernal/cmscan": {
                         "branch": "main",
                         "git_sha": "e29278872287d0599819456a2194f763da64aeb8",
-                        "installed_by": ["detect_rna"]
+                        "installed_by": [
+                            "detect_rna"
+                        ]
                     },
                     "infernal/cmsearch": {
                         "branch": "main",
                         "git_sha": "62e22fb1fd131d27ed043f305f317a0cf741b900",
-                        "installed_by": ["detect_rna"]
+                        "installed_by": [
+                            "detect_rna"
+                        ]
                     },
                     "interproscan": {
                         "branch": "main",
                         "git_sha": "75bee0dac2cb4b978fb62a8e8b8aab491507bb04",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/ebi-metagenomics/interproscan/interproscan.diff"
                     },
                     "keggpathwayscompleteness": {
                         "branch": "main",
                         "git_sha": "badc62913e6a5102f9c628a2b07baff39938d220",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/ebi-metagenomics/keggpathwayscompleteness/keggpathwayscompleteness.diff"
                     },
                     "krona/ktimporttext": {
                         "branch": "main",
                         "git_sha": "172e93318ac2e2db5f9885b07ffb80443e67848a",
-                        "installed_by": ["contigs_taxonomic_classification"]
+                        "installed_by": [
+                            "contigs_taxonomic_classification"
+                        ]
                     },
                     "mgnifypipelinestoolkit/kronatxtfromcatclassification": {
                         "branch": "main",
                         "git_sha": "3fd8d9bea7a1a459af0c0472899e62f7f8e5a2e8",
-                        "installed_by": ["contigs_taxonomic_classification"],
+                        "installed_by": [
+                            "contigs_taxonomic_classification"
+                        ],
                         "patch": "modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/mgnifypipelinestoolkit-kronatxtfromcatclassification.diff"
                     },
                     "mgnifypipelinestoolkit/rheachebiannotation": {
                         "branch": "main",
                         "git_sha": "7fbb802365177fd2a2f01ce5414c1c894357d95f",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/ebi-metagenomics/mgnifypipelinestoolkit/rheachebiannotation/mgnifypipelinestoolkit-rheachebiannotation.diff"
                     },
                     "mgnifypipelinestoolkit/summarisegoslims": {
                         "branch": "main",
                         "git_sha": "5b6cc0907498f48b2403346da520d08ec0a1d0c5",
-                        "installed_by": ["goslim_swf"],
+                        "installed_by": [
+                            "goslim_swf"
+                        ],
                         "patch": "modules/ebi-metagenomics/mgnifypipelinestoolkit/summarisegoslims/mgnifypipelinestoolkit-summarisegoslims.diff"
                     },
                     "owltools": {
                         "branch": "main",
                         "git_sha": "fb9a33114fe9083dc5b203fc4608825a9c51fdf6",
-                        "installed_by": ["goslim_swf"]
+                        "installed_by": [
+                            "goslim_swf"
+                        ]
                     },
                     "pyrodigal": {
                         "branch": "main",
                         "git_sha": "62a62db0834d95722de5a155778d70074b211dd6",
-                        "installed_by": ["combined_gene_caller"]
+                        "installed_by": [
+                            "combined_gene_caller"
+                        ]
                     },
                     "sanntis": {
                         "branch": "main",
                         "git_sha": "0d489b1617f2015cd99eea7f9369491723eb9260",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -226,23 +300,31 @@
                     "combined_gene_caller": {
                         "branch": "main",
                         "git_sha": "b84a0c52b92eef58ba2aeb2d22ae45d5bc6ae294",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "contigs_taxonomic_classification": {
                         "branch": "main",
                         "git_sha": "5fad0d0cf475b477119304430479d7d2d815a005",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "detect_rna": {
                         "branch": "main",
                         "git_sha": "937985d6147b25b74700f2eb6fc41ab4150ad7d4",
-                        "installed_by": ["subworkflows"],
+                        "installed_by": [
+                            "subworkflows"
+                        ],
                         "patch": "subworkflows/ebi-metagenomics/detect_rna/detect_rna.diff"
                     },
                     "goslim_swf": {
                         "branch": "main",
                         "git_sha": "fcd5bf454676aa301c45afd171916911ab4eec49",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,86 +8,64 @@
                     "antismash/antismashlite": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/antismash/antismashlite/antismash-antismashlite.diff"
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/cat/cat/cat-cat.diff"
                     },
                     "csvtk/concat": {
                         "branch": "master",
                         "git_sha": "fa92936611247ca647ddee970f94d83f1bcb0ffe",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/csvtk/concat/csvtk-concat.diff"
                     },
                     "hmmer/hmmsearch": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/hmmer/hmmsearch/hmmer-hmmsearch.diff"
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "cf17ca47590cc578dfb47db1c2a44ef86f89976d",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/multiqc/multiqc.diff"
                     },
                     "pigz/uncompress": {
                         "branch": "master",
                         "git_sha": "c70357ea249a541df53dd5b479b3c32b0c26c4d2",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "pyrodigal": {
                         "branch": "master",
                         "git_sha": "938e803109104e30773f76a7142442722498fef1",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "quast": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/quast/quast.diff"
                     },
                     "seqkit/seq": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "seqkit/split2": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/seqkit/split2/seqkit-split2.diff"
                     },
                     "tabix/bgzip": {
                         "branch": "master",
                         "git_sha": "69fdb99a8affa55adfda16966aa4568e103dc1b6",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             },
@@ -96,23 +74,17 @@
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "c2b22d85f30a706a3073387f30380704fcae013b",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "51ae5406a030d4da1e49e4dab49756844fdd6c7a",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "2fd2cd6d0e7b273747f32e465fdc6bcc3ae0814e",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     }
                 }
             }
@@ -123,175 +95,129 @@
                     "catpack/contigs": {
                         "branch": "main",
                         "git_sha": "b08ed4ae81778706db8c5be504bfd8dd2817a121",
-                        "installed_by": [
-                            "contigs_taxonomic_classification"
-                        ],
+                        "installed_by": ["contigs_taxonomic_classification"],
                         "patch": "modules/ebi-metagenomics/catpack/contigs/catpack-contigs.diff"
                     },
                     "cmsearchtbloutdeoverlap": {
                         "branch": "main",
                         "git_sha": "696324c637a7e0cf06fe331faffee42e36826898",
-                        "installed_by": [
-                            "detect_rna"
-                        ]
+                        "installed_by": ["detect_rna"]
                     },
                     "combinedgenecaller/merge": {
                         "branch": "main",
                         "git_sha": "b84a0c52b92eef58ba2aeb2d22ae45d5bc6ae294",
-                        "installed_by": [
-                            "combined_gene_caller"
-                        ],
+                        "installed_by": ["combined_gene_caller"],
                         "patch": "modules/ebi-metagenomics/combinedgenecaller/merge/combinedgenecaller-merge.diff"
                     },
                     "convertcmscantocmsearch": {
                         "branch": "main",
                         "git_sha": "937985d6147b25b74700f2eb6fc41ab4150ad7d4",
-                        "installed_by": [
-                            "detect_rna"
-                        ],
+                        "installed_by": ["detect_rna"],
                         "patch": "modules/ebi-metagenomics/convertcmscantocmsearch/convertcmscantocmsearch.diff"
                     },
                     "dbcan/dbcan": {
                         "branch": "main",
                         "git_sha": "2f2f837279b44825254ea736b12ea4797b350d0a",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/ebi-metagenomics/dbcan/dbcan/dbcan-dbcan.diff"
                     },
                     "diamond/blastp": {
                         "branch": "main",
                         "git_sha": "f85a33e88680924f76aaccb3c120983ff4134747",
-                        "installed_by": [
-                            "contigs_taxonomic_classification"
-                        ]
+                        "installed_by": ["contigs_taxonomic_classification"]
                     },
                     "dram/distill": {
                         "branch": "main",
                         "git_sha": "2ba3fbfba678c0c8e1e7537fa908b04575b5b916",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "easel/eslsfetch": {
                         "branch": "main",
                         "git_sha": "f1bf089cb679ca1e363aa81c99a512114402472c",
-                        "installed_by": [
-                            "detect_rna"
-                        ]
+                        "installed_by": ["detect_rna"]
                     },
                     "extractcoords": {
                         "branch": "main",
                         "git_sha": "33ea81307e5bf9772861d2a3cb1b4f4694a04db6",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/ebi-metagenomics/extractcoords/extractcoords.diff"
                     },
                     "fraggenescanrs": {
                         "branch": "main",
                         "git_sha": "67fa3c30f1488ebacb1f1a1304cc1c8b43e92e3d",
-                        "installed_by": [
-                            "combined_gene_caller"
-                        ]
+                        "installed_by": ["combined_gene_caller"]
                     },
                     "generategaf": {
                         "branch": "main",
                         "git_sha": "31e6276eef26fec7160c53a575b6e27b7ff842a5",
-                        "installed_by": [
-                            "goslim_swf"
-                        ],
+                        "installed_by": ["goslim_swf"],
                         "patch": "modules/ebi-metagenomics/generategaf/generategaf.diff"
                     },
                     "genomeproperties": {
                         "branch": "main",
                         "git_sha": "7c67b0652fb83c8239bd5bace72364f6676e3e39",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/ebi-metagenomics/genomeproperties/genomeproperties.diff"
                     },
                     "infernal/cmscan": {
                         "branch": "main",
                         "git_sha": "e29278872287d0599819456a2194f763da64aeb8",
-                        "installed_by": [
-                            "detect_rna"
-                        ]
+                        "installed_by": ["detect_rna"]
                     },
                     "infernal/cmsearch": {
                         "branch": "main",
                         "git_sha": "62e22fb1fd131d27ed043f305f317a0cf741b900",
-                        "installed_by": [
-                            "detect_rna"
-                        ]
+                        "installed_by": ["detect_rna"]
                     },
                     "interproscan": {
                         "branch": "main",
                         "git_sha": "75bee0dac2cb4b978fb62a8e8b8aab491507bb04",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/ebi-metagenomics/interproscan/interproscan.diff"
                     },
                     "keggpathwayscompleteness": {
                         "branch": "main",
                         "git_sha": "badc62913e6a5102f9c628a2b07baff39938d220",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/ebi-metagenomics/keggpathwayscompleteness/keggpathwayscompleteness.diff"
                     },
                     "krona/ktimporttext": {
                         "branch": "main",
                         "git_sha": "172e93318ac2e2db5f9885b07ffb80443e67848a",
-                        "installed_by": [
-                            "contigs_taxonomic_classification"
-                        ]
+                        "installed_by": ["contigs_taxonomic_classification"]
                     },
                     "mgnifypipelinestoolkit/kronatxtfromcatclassification": {
                         "branch": "main",
                         "git_sha": "3fd8d9bea7a1a459af0c0472899e62f7f8e5a2e8",
-                        "installed_by": [
-                            "contigs_taxonomic_classification"
-                        ],
+                        "installed_by": ["contigs_taxonomic_classification"],
                         "patch": "modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/mgnifypipelinestoolkit-kronatxtfromcatclassification.diff"
                     },
                     "mgnifypipelinestoolkit/rheachebiannotation": {
                         "branch": "main",
                         "git_sha": "7fbb802365177fd2a2f01ce5414c1c894357d95f",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/ebi-metagenomics/mgnifypipelinestoolkit/rheachebiannotation/mgnifypipelinestoolkit-rheachebiannotation.diff"
                     },
                     "mgnifypipelinestoolkit/summarisegoslims": {
                         "branch": "main",
                         "git_sha": "5b6cc0907498f48b2403346da520d08ec0a1d0c5",
-                        "installed_by": [
-                            "goslim_swf"
-                        ],
+                        "installed_by": ["goslim_swf"],
                         "patch": "modules/ebi-metagenomics/mgnifypipelinestoolkit/summarisegoslims/mgnifypipelinestoolkit-summarisegoslims.diff"
                     },
                     "owltools": {
                         "branch": "main",
                         "git_sha": "fb9a33114fe9083dc5b203fc4608825a9c51fdf6",
-                        "installed_by": [
-                            "goslim_swf"
-                        ]
+                        "installed_by": ["goslim_swf"]
                     },
                     "pyrodigal": {
                         "branch": "main",
                         "git_sha": "62a62db0834d95722de5a155778d70074b211dd6",
-                        "installed_by": [
-                            "combined_gene_caller"
-                        ]
+                        "installed_by": ["combined_gene_caller"]
                     },
                     "sanntis": {
                         "branch": "main",
                         "git_sha": "0d489b1617f2015cd99eea7f9369491723eb9260",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             },
@@ -300,31 +226,23 @@
                     "combined_gene_caller": {
                         "branch": "main",
                         "git_sha": "b84a0c52b92eef58ba2aeb2d22ae45d5bc6ae294",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "contigs_taxonomic_classification": {
                         "branch": "main",
                         "git_sha": "5fad0d0cf475b477119304430479d7d2d815a005",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "detect_rna": {
                         "branch": "main",
                         "git_sha": "937985d6147b25b74700f2eb6fc41ab4150ad7d4",
-                        "installed_by": [
-                            "subworkflows"
-                        ],
+                        "installed_by": ["subworkflows"],
                         "patch": "subworkflows/ebi-metagenomics/detect_rna/detect_rna.diff"
                     },
                     "goslim_swf": {
                         "branch": "main",
                         "git_sha": "fcd5bf454676aa301c45afd171916911ab4eec49",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     }
                 }
             }

--- a/modules/ebi-metagenomics/catpack/contigs/catpack-contigs.diff
+++ b/modules/ebi-metagenomics/catpack/contigs/catpack-contigs.diff
@@ -4,7 +4,16 @@ Changes in component 'ebi-metagenomics/catpack/contigs'
 Changes in 'catpack/contigs/main.nf':
 --- modules/ebi-metagenomics/catpack/contigs/main.nf
 +++ modules/ebi-metagenomics/catpack/contigs/main.nf
-@@ -29,12 +29,15 @@
+@@ -16,7 +16,7 @@
+ 
+     output:
+     tuple val(meta), path("*.ORF2LCA.txt"), emit: orf2lca
+-    tuple val(meta), path("*.contig2classification.txt"), emit: contig2classification
++    tuple val(meta), path("*.contig2classification.txt.gz"), emit: contig2classification
+     tuple val(meta), path("*.log"), emit: log
+     tuple val(meta), path("*.diamond"), optional: true, emit: diamond
+     tuple val(meta), path("*.predicted_proteins.faa"), optional: true, emit: faa
+@@ -29,18 +29,23 @@
      script:
      def args = task.ext.args ?: ''
      def prefix = task.ext.prefix ?: "${meta.id}"
@@ -22,6 +31,14 @@ Changes in 'catpack/contigs/main.nf':
          --database_folder ${database} \\
          --taxonomy_folder ${taxonomy} \\
          --out_prefix ${prefix} \\
+         ${premade_proteins} \\
+         ${premade_table} \\
+         ${args}
++
++    gzip ${prefix}.contig2classification.txt
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
 
 'modules/ebi-metagenomics/catpack/contigs/tests/main.nf.test.snap' is unchanged
 'modules/ebi-metagenomics/catpack/contigs/tests/nextflow.config' is unchanged

--- a/modules/ebi-metagenomics/catpack/contigs/main.nf
+++ b/modules/ebi-metagenomics/catpack/contigs/main.nf
@@ -16,7 +16,7 @@ process CATPACK_CONTIGS {
 
     output:
     tuple val(meta), path("*.ORF2LCA.txt"), emit: orf2lca
-    tuple val(meta), path("*.contig2classification.txt"), emit: contig2classification
+    tuple val(meta), path("*.contig2classification.txt.gz"), emit: contig2classification
     tuple val(meta), path("*.log"), emit: log
     tuple val(meta), path("*.diamond"), optional: true, emit: diamond
     tuple val(meta), path("*.predicted_proteins.faa"), optional: true, emit: faa
@@ -44,6 +44,8 @@ process CATPACK_CONTIGS {
         ${premade_proteins} \\
         ${premade_table} \\
         ${args}
+
+    gzip ${prefix}.contig2classification.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/main.nf
+++ b/modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/main.nf
@@ -19,8 +19,10 @@ process MGNIFYPIPELINESTOOLKIT_KRONATXTFROMCATCLASSIFICATION {
 
     script:
     """
+    gunzip ${cat_output}
+
     krona_txt_from_cat_classification \\
-        --input ${cat_output} \\
+        --input ${cat_output.name.replace(".gz", "")} \\
         --output ${meta.id}.krona.txt \\
         --names_dmp ${taxonomy}/names.dmp \\
         --nodes_dmp ${taxonomy}/nodes.dmp

--- a/modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/mgnifypipelinestoolkit-kronatxtfromcatclassification.diff
+++ b/modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/mgnifypipelinestoolkit-kronatxtfromcatclassification.diff
@@ -1,4 +1,6 @@
-Changes in module 'ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification'
+Changes in component 'ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification'
+'modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/meta.yml' is unchanged
+Changes in 'mgnifypipelinestoolkit/kronatxtfromcatclassification/main.nf':
 --- modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/main.nf
 +++ modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/main.nf
 @@ -2,7 +2,9 @@
@@ -12,5 +14,22 @@ Changes in module 'ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassi
  
      input:
      tuple val(meta), path(cat_output)
+@@ -17,8 +19,10 @@
+ 
+     script:
+     """
++    gunzip ${cat_output}
++
+     krona_txt_from_cat_classification \\
+-        --input ${cat_output} \\
++        --input ${cat_output.name.replace(".gz", "")} \\
+         --output ${meta.id}.krona.txt \\
+         --names_dmp ${taxonomy}/names.dmp \\
+         --nodes_dmp ${taxonomy}/nodes.dmp
 
+'modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/tests/main.nf.test.snap' is unchanged
+'modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/tests/main.nf.test' is unchanged
+'modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/tests/data/cat.tsv' is unchanged
+'modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/tests/data/tax/names.dmp' is unchanged
+'modules/ebi-metagenomics/mgnifypipelinestoolkit/kronatxtfromcatclassification/tests/data/tax/nodes.dmp' is unchanged
 ************************************************************


### PR DESCRIPTION
Compression was missing from the CAT output, this PR adds that, and subsequently adds decompression at the beginning of the other relevant module that uses that output downstream