### PR TITLE
Removes `_concatenated` from published antismash/sanntis gff filenames

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -400,7 +400,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/pathways-and-systems/antismash" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll('_concatenated', '') },
         ]
     }
 
@@ -408,7 +408,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/pathways-and-systems/antismash" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll('_concatenated', '') },
         ]
     }
 
@@ -417,7 +417,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/pathways-and-systems/sanntis" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename.replaceAll('_concatenated', '') },
         ]
     }
 


### PR DESCRIPTION
<!--
# ebi-metagenomics/assembly-analysis-pipeline pull request

Many thanks for contributing to ebi-metagenomics/assembly-analysis-pipeline!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/tree/main/.github/CONTRIBUTING.md)
-->

This PR: renames a couple of the `antismash` and `sanntis` files in the `results` directory, just removing the `..._concatenated` chunk of their filenames, since the chunking/concatenating of the GFFs is an implementation detail that is not important to the end result. This makes the naming more consistent across result types for the post-pipeline study summary generation at MGnify.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated. 
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
