### PR TITLE
Allow .fa, .fa.gz etc for assembly fasta input

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -17,8 +17,8 @@
                 "type": "string",
                 "format": "file-path",
                 "exists": true,
-                "pattern": "^\\S+\\.fasta(\\.gz)?$",
-                "errorMessage": "The assembly needs to be a fasta file, either '.fasta.gz' or '.fasta'"
+                "pattern": "^\\S+\\.(fasta|fa|fna|ffn)(\\.gz)?$",
+                "errorMessage": "The assembly needs to be a fasta file, either '.fasta', '.fa', '.fna', or '.ffn' (all with or without '.gz')"
             }
         },
         "required": ["sample", "assembly_fasta"]


### PR DESCRIPTION
Some assemblies in ENA have filetype suffixes other than .fasta(±.gz). E.g. `ftp.sra.ebi.ac.uk/vol1/sequence/ERZ174/ERZ1740926/contig.fa.gz`.
This PR allows some other common fasta suffixes.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
_Tested locally with .fa.gz but not really worth adding more test files just for this_
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
