### PR TITLE
Add the gt GFF validation module - run on the summary gff

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -28,7 +28,7 @@
 
 - [Krona](http://dx.doi.org/10.1186/1471-2105-12-385)
 
-  > Ondov BD, Bergman NH, Phillippy AM. Interactive metagenomic visualization in a Web browser. Vol. 12, BMC Bioinformatics. Springer Science and Business Media LLC; 201Available from: http://dx.doi.org/10.1186/1471-2105-12-385
+  > Ondov BD, Bergman NH, Phillippy AM. Interactive metagenomic visualization in a Web browser. Vol. 12, BMC Bioinformatics. Springer Science and Business Media LLC; 201. Available from: http://dx.doi.org/10.1186/1471-2105-12-385
 
 - [Pyrodigal](http://dx.doi.org/10.21105/joss.04296)
 
@@ -36,7 +36,7 @@
 
 - [dbCAN](http://dx.doi.org/10.1093/nar/gkad328)
 
-  > Zheng J, Ge Q, Yan Y, Zhang X, Huang L, Yin Y. dbCAN3: automated carbohydrate-active enzyme and substrate annotation. Vol. 51, Nucleic Acids Research. Oxford University Press (OUP); 2023. p. W115–2Available from: http://dx.doi.org/10.1093/nar/gkad328
+  > Zheng J, Ge Q, Yan Y, Zhang X, Huang L, Yin Y. dbCAN3: automated carbohydrate-active enzyme and substrate annotation. Vol. 51, Nucleic Acids Research. Oxford University Press (OUP); 2023. p. W115–2. Available from: http://dx.doi.org/10.1093/nar/gkad328
 
 - [InterProScan](http://dx.doi.org/10.1093/bioinformatics/btu031)
 
@@ -81,6 +81,10 @@
 - [SeqKit](http://dx.doi.org/10.1371/journal.pone.0163962)
 
   > Shen W, Le S, Li Y, Hu F. SeqKit: A Cross-Platform and Ultrafast Toolkit for FASTA/Q File Manipulation. Zou Q, editor. Vol. 11, PLOS ONE. Public Library of Science (PLoS); 2016. p. e0163962. Available from: http://dx.doi.org/10.1371/journal.pone.0163962
+
+- [Genome Tools](http://dx.doi.org/10.1109/TCBB.2013.68)
+
+  > G. Gremme, S. Steinbiss and S. Kurtz. "GenomeTools: A Comprehensive Software Library for Efficient Processing of Structured Genome Annotations" in IEEE/ACM Transactions on Computational Biology and Bioinformatics, vol. 10, no. 03, pp. 645-656, May-June 2013, Available from: http://dx.doi.org/10.1109/TCBB.2013.68.
 
 ## Software packaging/containerisation tools
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The MGnify assembly analysis pipeline, version 6.0.0 and onwards, provides the f
   - [run_dbCAN](https://github.com/bcb-unl/run_dbcan): Annotates carbohydrate-active enzymes.
   - [KEGG Orthologs](https://www.genome.jp/kegg/ko.html): Assigns KEGG Orthologs (KO) identifiers using HMMER.
   - [RHEA](https://www.rhea-db.org/): Proteins are assigned RHEA ids.
-- Biosynthetic Gene Cluster Annotation: The pipeline uses [AntiSMASH](https://antismash.secondarymetabolites.org/) and [SanntiS](https://github.com/Finn-Lab/SanntiS) to identify and annotate biosynthetic gene clusters associated with secondary metabolite production.
+- Biosynthetic Gene Cluster Annotation: The pipeline uses [antiSMASH](https://antismash.secondarymetabolites.org/) and [SanntiS](https://github.com/Finn-Lab/SanntiS) to identify and annotate biosynthetic gene clusters associated with secondary metabolite production.
 - KEGG Modules completeness: The pipeline analyzes the KEGG Orthologs annotations to infer the presence and completeness of KEGG modules.
 - Consolidated annotation: The pipeline aggregates all the generated annotations into a single consolidated GFF file.
 
@@ -66,6 +66,7 @@ The MGnify assembly analysis pipeline, version 6.0.0 and onwards, provides the f
 | [SeqKit](https://bioinf.shenwei.me/seqkit/)                                                       |         | Used to manipulate FASTA files                                                                                 |
 | [SanntiS](https://github.com/Finn-Lab/SanntiS)                                                    |         | Tool used to identify biosynthetic gene clusters                                                               |
 | [tabix](http://www.htslib.org/doc/tabix.html)                                                     |         | Generic indexer for TAB-delimited genome position files                                                        |
+| [Genome Tools - gff3validator](https://genometools.org/tools/gt_gff3validator.html)               |         | Used to validate the analysis summary GFF file                                                                 |
 
 ### Reference databases
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -474,7 +474,15 @@ process {
             path: { "${params.outdir}/${meta.id}/annotation-summary" },
             mode: params.publish_dir_mode,
             pattern: "*summary.gff.gz",
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        ]
+    }
+
+    withName: "GT_GFF3VALIDATOR" {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/annotation-summary" },
+            mode: params.publish_dir_mode,
+            pattern: "*error.log",
+            saveAs: { _filename -> "${meta.id}_gff_validation_errors.log" },
         ]
     }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -276,6 +276,7 @@ The `annotation-summary` directory contains a single file that summarises the an
 #### Output files
 
 - **ERZ12345_annotation_summary.gff.gz**: This `gff` file contains an expansive and large summary of most of the functional annotations each protein has into a single GFF3 format file.
+- **ERZ12345_gff_validation_errors.log**: **If** [the GFF file is not valid](https://genometools.org/tools/gt_gff3validator.html), then a log file is created with the validation errors.
 
 ## Per-study output files
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -281,14 +281,21 @@ The `annotation-summary` directory contains a single file that summarises the an
 
 The pipeline generates four different per-study output files that aggregate and summarise data, from successful assembly analysis runs to study-wide [MultiQC](https://github.com/MultiQC/MultiQC) reports. These are stored at the root of the study analysis directory.
 
-### Successfully analysed assemblies
+### Analysed assemblies
 
-The IDs of assemblies that have been successfully analysed are aggregated into a top-level file (`analysed_assemblies.csv`), which looks like this:
+The IDs of assemblies that have been analysed are aggregated into a top-level file (`analysed_assemblies.csv`), which looks like this:
 
 ```
 ERZ12345,success
 ERZ56789,success
 ```
+
+#### The possible statuses are
+
+| Status              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| success             | The assembly was successfully annotated                        |
+| invalid_summary_gff | The assembly summary GFF file is not valid, treat with caution |
 
 ### MultiQC
 

--- a/modules.json
+++ b/modules.json
@@ -23,6 +23,11 @@
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/csvtk/concat/csvtk-concat.diff"
                     },
+                    "gt/gff3validator": {
+                        "branch": "master",
+                        "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
+                        "installed_by": ["modules"]
+                    },
                     "hmmer/hmmsearch": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",

--- a/modules/nf-core/gt/gff3validator/environment.yml
+++ b/modules/nf-core/gt/gff3validator/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::genometools-genometools=1.6.5

--- a/modules/nf-core/gt/gff3validator/main.nf
+++ b/modules/nf-core/gt/gff3validator/main.nf
@@ -1,0 +1,61 @@
+process GT_GFF3VALIDATOR {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/genometools-genometools:1.6.5--py310h3db02ab_0':
+        'biocontainers/genometools-genometools:1.6.5--py310h3db02ab_0' }"
+
+    input:
+    tuple val(meta), path(gff3)
+
+    output:
+    tuple val(meta), path('*.success.log')  , emit: success_log , optional: true
+    tuple val(meta), path('*.error.log')    , emit: error_log   , optional: true
+    path "versions.yml"                     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    gt \\
+        gff3validator \\
+        "$gff3" \\
+        > "${prefix}.stdout" \\
+        2> >(tee "${prefix}.stderr" >&2) \\
+        || echo "Errors from gt-gff3validator printed to ${prefix}.error.log"
+
+    if grep -q "input is valid GFF3" "${prefix}.stdout"; then
+        echo "Validation successful..."
+        # emit stdout to the success output channel
+        mv \\
+            "${prefix}.stdout" \\
+            "${prefix}.success.log"
+    else
+        echo "Validation failed..."
+        # emit stderr to the error output channel
+        mv \\
+            "${prefix}.stderr" \\
+            "${prefix}.error.log"
+    fi
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        genometools: \$(gt --version | head -1 | sed 's/gt (GenomeTools) //')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch "${prefix}.success.log"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        genometools: \$(gt --version | head -1 | sed 's/gt (GenomeTools) //')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/gt/gff3validator/meta.yml
+++ b/modules/nf-core/gt/gff3validator/meta.yml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "gt_gff3validator"
+description: "GenomeTools gt-gff3validator utility to strictly validate a GFF3 file"
+keywords:
+  - genome
+  - gff3
+  - annotation
+  - validation
+tools:
+  - "gt":
+      description: "The GenomeTools genome analysis system"
+      homepage: "https://genometools.org/index.html"
+      documentation: "https://genometools.org/documentation.html"
+      tool_dev_url: "https://github.com/genometools/genometools"
+      doi: "10.1109/TCBB.2013.68"
+      licence: ["ISC"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test' ]`
+    - gff3:
+        type: file
+        description: Input gff3 file
+        pattern: "*.{gff,gff3}"
+output:
+  - success_log:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test' ]`
+      - "*.success.log":
+          type: file
+          description: Log file for successful validation
+          pattern: "*.success.log"
+  - error_log:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'test' ]`
+      - "*.error.log":
+          type: file
+          description: Log file for failed validation
+          pattern: "*.error.log"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/gt/gff3validator/tests/main.nf.test
+++ b/modules/nf-core/gt/gff3validator/tests/main.nf.test
@@ -1,0 +1,98 @@
+nextflow_process {
+
+    name "Test Process GT_GFF3VALIDATOR"
+    script "../main.nf"
+    process "GT_GFF3VALIDATOR"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gt"
+    tag "gt/gff3validator"
+    tag "gt/gff3"
+
+    test("sarscov2-gff3-valid") {
+
+        config './nextflow.config'
+
+        setup {
+            run("GT_GFF3") {
+                script "../../../gt/gff3"
+
+                process {
+                    """
+                    input[0] = [
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3', checkIfExists: true)
+                    ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GT_GFF3.out.gt_gff3
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.success_log[0][1]).text.contains("input is valid GFF3") },
+                { assert process.out.error_log == [] },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2-gff3-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gff3', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2-gff3-invalid") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gff3', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.error_log[0][1]).text.contains("gt gff3validator: error:") },
+                { assert process.out.success_log == [] },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+}

--- a/modules/nf-core/gt/gff3validator/tests/main.nf.test.snap
+++ b/modules/nf-core/gt/gff3validator/tests/main.nf.test.snap
@@ -1,0 +1,107 @@
+{
+    "sarscov2-gff3-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.success.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    "versions.yml:md5,5927673eb73a8c22408643d224414215"
+                ],
+                "error_log": [
+                    
+                ],
+                "success_log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.success.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5927673eb73a8c22408643d224414215"
+                ]
+            }
+        ],
+        "timestamp": "2024-01-11T09:29:13.14468"
+    },
+    "sarscov2-gff3-invalid": {
+        "content": [
+            {
+                "0": [
+                    
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.error.log:md5,c5d16b263a87072a13cca44fd811b8e2"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,5927673eb73a8c22408643d224414215"
+                ],
+                "error_log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.error.log:md5,c5d16b263a87072a13cca44fd811b8e2"
+                    ]
+                ],
+                "success_log": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,5927673eb73a8c22408643d224414215"
+                ]
+            }
+        ],
+        "timestamp": "2023-11-29T11:09:23.708792"
+    },
+    "sarscov2-gff3-valid": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.success.log:md5,b11ca5c18c865fc808ea0fef0b07da30"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    "versions.yml:md5,5927673eb73a8c22408643d224414215"
+                ],
+                "error_log": [
+                    
+                ],
+                "success_log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.success.log:md5,b11ca5c18c865fc808ea0fef0b07da30"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5927673eb73a8c22408643d224414215"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-13T10:34:54.485391"
+    }
+}

--- a/modules/nf-core/gt/gff3validator/tests/nextflow.config
+++ b/modules/nf-core/gt/gff3validator/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: GT_GFF3 {
+        ext.args = '-tidy -retainids'
+    }
+}

--- a/workflows/assembly_analysis_pipeline.nf
+++ b/workflows/assembly_analysis_pipeline.nf
@@ -19,6 +19,7 @@ include { methodsDescriptionText             } from '../subworkflows/local/utils
 include { SEQKIT_SPLIT2                      } from '../modules/nf-core/seqkit/split2/main'
 include { PIGZ_UNCOMPRESS as PIGZ_CONTIGS    } from '../modules/nf-core/pigz/uncompress/main'
 include { PIGZ_UNCOMPRESS as PIGZ_PROTEINS   } from '../modules/nf-core/pigz/uncompress/main'
+include { GT_GFF3VALIDATOR                   } from '../modules/nf-core/gt/gff3validator/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,6 +186,20 @@ workflow ASSEMBLY_ANALYSIS_PIPELINE {
         )
     )
     ch_versions = ch_versions.mix(GFF_SUMMARY.out.versions)
+
+    // Run the genometools GFF validation
+    // If there are any errors with the GFF, these will be added to a log file for further inspection,
+    // but an invalid GFF won't make the pipeline fail. Doing so would be a waste of compute and not
+    // something we could take care of at this point of the execution.
+    // This is based on the assumption that we will test the pipeline with loads of different kinds of assemblies and by then
+    // we should have ironed out any issues.
+    // The log file will be used in the automation system to flag the jobs for inspection.
+    // But, I'm up to discuss this @mberacochea
+    // TODO: Maybe add a parameter to make the pipeline fail on invalid GFF?
+    GT_GFF3VALIDATOR(
+        GFF_SUMMARY.out.gff_summary
+    )
+    ch_versions = ch_versions.mix(GT_GFF3VALIDATOR.out.versions)
 
     //
     // Collate and save software versions

--- a/workflows/assembly_analysis_pipeline.nf
+++ b/workflows/assembly_analysis_pipeline.nf
@@ -284,10 +284,11 @@ workflow ASSEMBLY_ANALYSIS_PIPELINE {
     // specifically those without IPS annotations or BGC. We need to retrieve
     // examples of these assemblies from the current backlog database.
 
-    GFF_SUMMARY.out.gff_summary
-        .map { meta, __ ->
+
+    GFF_SUMMARY.out.gff_summary.join(GT_GFF3VALIDATOR.out.error_log, remainder: true)
+        .map { meta, _gff_summary, gff_validation_error ->
             {
-                return "${meta.id},success"
+                return "${meta.id},${ (!gff_validation_error) ? 'success' : 'invalid_summary_gff' }"
             }
         }
         .collectFile(name: "analysed_assemblies.csv", storeDir: params.outdir, newLine: true, cache: false)


### PR DESCRIPTION
Run the genometools GFF validation

If there are any errors with the GFF, these will be added to a log file for further inspection, but an invalid GFF won't make the pipeline fail. Doing so would be a waste of compute and not something we could take care of at this point of the execution. This is based on the assumption that we will test the pipeline with loads of different kinds of assemblies and by then we should have ironed out any issues.

The log file will be used in the automation system to flag the jobs for inspection.

But, I'm up to discuss this. I'll add this file to the output.md after reaching a consensus.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
