### PR TITLE
HMMSEARCH KOfam -> noali flag

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -130,6 +130,11 @@ process {
         cpus   = { 4     * task.attempt }
         memory = { 16.GB  * task.attempt }
         time   = { 16.h   * task.attempt }
+
+        // Don't write the alignment in the output, we don't use it so this should
+        // improve the performance (the alingments are very verbose)
+        ext.args = { "--noali" }
+
         // We override the prefix of the output here because the input is chunked and joined with CAT_CAT
         // and to avoid naming collisions we use the name of the input (which comes from SEQKIT_SPLIT2) that
         // contains the chunk part in it.


### PR DESCRIPTION
Don't write the alignment in the output, we don't use it so this should improve the performance (the alingments are very verbose)

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
