### PR TITLE
Chores/bump resources for minimap align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.3] - 2026-06-26
+
+### Changed
+
+- Increased the runtime and memory minimap2_align uses by default.
+
 ## [6.0.2] - 2026-04-24
 
 ### Fixed

--- a/conf/base.config
+++ b/conf/base.config
@@ -15,7 +15,7 @@ process {
     time   = { 4.h    * task.attempt }
 
     errorStrategy = {
-        if (task.exitStatus == null || task.exitStatus in ((130..145) + 104)) {
+        if ( task.exitStatus == null || task.exitStatus in ((130..145) + 104) ) {
             return 'retry'
         }
         return 'finish'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,6 +35,11 @@ process {
         ext.prefix = { "${meta.id}_cleaned" }
     }
 
+    withName: MINIMAP2_ALIGN {
+        memory = { 100.GB * task.attempt }
+        time   = { 24.h   * task.attempt }
+    }
+
     withName: 'EBIMETAGENOMICS:ASSEMBLY_ANALYSIS_PIPELINE:ASSEMBLY_QC:ASSEMBLY_DECONTAMINATION:HUMAN_DECONTAMINATE_CONTIGS:FILTERPAF' {
         // TSV with the contaminated contigs, identify and coverage (mapping values)
         ext.prefix = { "${meta.id}_human" }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,7 +35,7 @@ process {
         ext.prefix = { "${meta.id}_cleaned" }
     }
 
-    withName: MINIMAP2_ALIGN {
+    withName: "EBIMETAGENOMICS:ASSEMBLY_ANALYSIS_PIPELINE:ASSEMBLY_QC:ASSEMBLY_DECONTAMINATION:HOST_DECONTAMINATE_CONTIGS:MINIMAP2_ALIGN" {
         memory = { 100.GB * task.attempt }
         time   = { 24.h   * task.attempt }
     }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,7 +113,7 @@ nextflow pull ebi-metagenomics/assembly-analysis-pipeline
 
 It is a good idea to specify the pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
 
-First, go to the [ebi-metagenomics/assembly-analysis-pipeline releases page](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/releases) and find the latest pipeline version - numeric only (eg. `6.0.2`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 6.0.2`. Of course, you can switch to another version by changing the number after the `-r` flag.
+First, go to the [ebi-metagenomics/assembly-analysis-pipeline releases page](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/releases) and find the latest pipeline version - numeric only (eg. `6.0.3`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 6.0.3`. Of course, you can switch to another version by changing the number after the `-r` flag.
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future. For example, at the bottom of the MultiQC reports.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -397,7 +397,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=24.10.3'
-    version         = '6.0.2'
+    version         = '6.0.3'
     doi             = '10.1093/nar/gkac1080'
 }
 

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -233,7 +233,7 @@
                     "tabix": 1.2
                 },
                 "Workflow": {
-                    "ebi-metagenomics/assembly-analysis-pipeline": "v6.0.2"
+                    "ebi-metagenomics/assembly-analysis-pipeline": "v6.0.3"
                 }
             },
             [


### PR DESCRIPTION
Bump the memory and time limit of minimap2, useful when using large genomes to decontaminate.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/ebi-metagenomics/assembly-analysis-pipeline/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
